### PR TITLE
Add support for matching arrays in payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ There are three ways of running the extension:
 
 The extension accepts the following parameters:
 * `header`: Key-value map of header fields to match, e.g. `{ "alg": "HS256" }`
-* `payload`: Key-value map of payload fields to match, e.g. `{ "admin": true }`
+* `payload`: Key-value map of payload fields to match, e.g. `{ "admin": true }`. If the value is an array (e.g. `{ "aud": ["aud1", "aud2"] }`, it will be matched exactly.
 * `request`: Any additional request matchers. This is basically a workaround for the inability to compose extensions in WireMock.
 
 When using the API, make sure to set the `"name"` field of the customMatcher to `"jwt-matcher"`.  Here's an example cURL command that creates a stub mapping with the request matcher:
@@ -56,7 +56,8 @@ curl -d@- http://localhost:8080/__admin/mappings <<-EOD
                     "typ": "JWT"
                 },
                 "payload": {
-                    "name" : "John Doe"
+                    "name" : "John Doe",
+                    "aud": ["aud1", "aud2"]
                 },
                 "request" : {
                     "url" : "/some_url",
@@ -75,7 +76,7 @@ EOD
 
 Example request that matches the above stub mapping:
 ```sh
-curl -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.XbPfbIHMI6arZ3Y922BhjWgQzWXcXNrz0ogtVhfEd2o' http://localhost:8080/some_url
+curl -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJhdWQiOlsiYXVkMSIsImF1ZDIiXX0.h49E7AnYrJpttdEoi4GmoZUCtg6GBSHTSjUcDGnbjRI' http://localhost:8080/some_url
 ```
 
 # Stub mapping transformer usage

--- a/src/main/java/com/github/masonm/JwtMatcherExtension.java
+++ b/src/main/java/com/github/masonm/JwtMatcherExtension.java
@@ -65,12 +65,12 @@ public class JwtMatcherExtension extends RequestMatcherExtension {
     }
 
     private boolean matchParams(JsonNode tokenValues, Object parameters) {
-        Map<String, String> parameterMap = new ObjectMapper().convertValue(
+        Map<String, JsonNode> parameterMap = new ObjectMapper().convertValue(
             parameters,
-            new TypeReference<Map<String, Object>>() {}
+            new TypeReference<Map<String, JsonNode>>() {}
         );
-        for (Map.Entry<String, String> entry: parameterMap.entrySet()) {
-            String tokenValue = tokenValues.path(entry.getKey()).asText();
+        for (Map.Entry<String, JsonNode> entry: parameterMap.entrySet()) {
+            JsonNode tokenValue = tokenValues.path(entry.getKey());
             if (!Objects.equals(tokenValue, entry.getValue())) {
                 return false;
             }

--- a/src/test/java/com/github/masonm/JwtStubMappingTransformerTest.java
+++ b/src/test/java/com/github/masonm/JwtStubMappingTransformerTest.java
@@ -60,7 +60,10 @@ public class JwtStubMappingTransformerTest {
 
     @Test
     public void returnsModifiedMappingWhenMatchingValidPayloadField() {
-        final TestAuthHeader testAuthHeader = new TestAuthHeader("doesnt_matter", "matched");
+        final TestAuthHeader testAuthHeader = new TestAuthHeader(
+            "doesnt_matter",
+            "{ \"matched_key\": \"matched_value\" }"
+        );
         StubMapping testMapping = WireMock
             .get("/")
             .withHeader("Authorization", WireMock.equalTo(testAuthHeader.toString()))
@@ -86,7 +89,10 @@ public class JwtStubMappingTransformerTest {
 
     @Test
     public void acceptanceTestReturnsModifiedMappingWhenMatchingValidPayloadField() {
-        final TestAuthHeader testAuthHeader = new TestAuthHeader("doesnt_matter", "matched");
+        final TestAuthHeader testAuthHeader = new TestAuthHeader(
+            "doesnt_matter",
+            "{ \"matched_key\": \"matched_value\" }"
+        );
         StubMapping testMapping = WireMock
             .get("/")
             .withHeader("Host", WireMock.equalTo("www.example.com"))

--- a/src/test/java/com/github/masonm/JwtTest.java
+++ b/src/test/java/com/github/masonm/JwtTest.java
@@ -13,8 +13,8 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 public class JwtTest {
-    public static final String UNSECURED_TEST_TOKEN = "eyJhbGciOiJub25lIn0.eyJuYW1lIjoiTWFzb24gTWFsb25lIn0.";
-    public static final String SECURED_TEST_HEADER = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ik1hc29uIE1hbG9uZSIsImlhdCI6MTUxNjIzOTAyMn0.MAzWSeaKvOgZb8_uasPYK681tF7PfC0E2AmfDsLfefs";
+    private static final String UNSECURED_TEST_TOKEN = "eyJhbGciOiJub25lIn0.eyJuYW1lIjoiTWFzb24gTWFsb25lIn0.";
+    private static final String SECURED_TEST_HEADER = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ik1hc29uIE1hbG9uZSIsImlhdCI6MTUxNjIzOTAyMn0.MAzWSeaKvOgZb8_uasPYK681tF7PfC0E2AmfDsLfefs";
 
     @Test
     public void constructorUsesAbsentForInvalidTokens() {

--- a/src/test/java/com/github/masonm/TestAuthHeader.java
+++ b/src/test/java/com/github/masonm/TestAuthHeader.java
@@ -1,52 +1,24 @@
 package com.github.masonm;
 
 import org.apache.commons.codec.binary.Base64;
-import com.github.tomakehurst.wiremock.extension.Parameters;
-import com.google.common.collect.ImmutableMap;
 
 /**
- * Generates a Authorization header string for testing purposes, and
- * can return Parameters objects to use for request matching against the header
+ * Generates an Authorization header string for testing purposes
  */
 public class TestAuthHeader {
-    private String headerPrefix;
-    private String payloadPrefix;
+    private final String header;
+    private final String payload;
 
-    public TestAuthHeader(String headerPrefix, String payloadPrefix) {
-        this.headerPrefix = headerPrefix;
-        this.payloadPrefix = payloadPrefix;
+    public TestAuthHeader(String header, String payload) {
+        this.header = header;
+        this.payload = payload;
     }
 
-    public String getEncodedHeader() {
-        final String headerJson = "{ \"" + headerPrefix + "_key\": \"" + headerPrefix + "_value\" }";
-        return Base64.encodeBase64URLSafeString(headerJson.getBytes());
-    }
-
-    public String getEncodedPayload() {
-        final String payloadJson = "{ \"" + payloadPrefix + "_key\": \"" + payloadPrefix + "_value\" }";
-        return Base64.encodeBase64URLSafeString(payloadJson.getBytes());
+    private String encode(String value) {
+        return Base64.encodeBase64URLSafeString(value.getBytes());
     }
 
     public String toString() {
-        return "Bearer " + getEncodedHeader() + "." + getEncodedPayload() + ".dummy_signature";
-    }
-
-    public Parameters getHeaderMatchParams() {
-        return Parameters.one(
-            JwtMatcherExtension.PARAM_NAME_HEADER, ImmutableMap.of(headerPrefix + "_key", headerPrefix + "_value")
-        );
-    }
-
-    public Parameters getPayloadMatchParameters() {
-        return Parameters.one(
-            JwtMatcherExtension.PARAM_NAME_PAYLOAD, ImmutableMap.of(payloadPrefix + "_key", payloadPrefix + "_value")
-        );
-    }
-
-    public Parameters getBothMatchParameters() {
-        return new Parameters() {{
-            putAll(getHeaderMatchParams());
-            putAll(getPayloadMatchParameters());
-        }};
+        return "Bearer " + encode(header) + "." + encode(payload) + ".dummy_signature";
     }
 }

--- a/test-request-match.sh
+++ b/test-request-match.sh
@@ -19,7 +19,8 @@ curl -d@- http://localhost:8080/__admin/mappings <<-EOD
                     "typ": "JWT"
                 },
                 "payload": {
-                    "name" : "John Doe"
+                    "name" : "John Doe",
+                    "aud": ["foo", "bar"]
                 },
                 "request" : {
                     "url" : "/some_url",
@@ -36,4 +37,4 @@ curl -d@- http://localhost:8080/__admin/mappings <<-EOD
 EOD
 
 echo -e "done\n\nMaking request"
-curl -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.XbPfbIHMI6arZ3Y922BhjWgQzWXcXNrz0ogtVhfEd2o' http://localhost:8080/some_url
+curl -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJhdWQiOlsiZm9vIiwiYmFyIl19.aqa_OxjpGtC4nHVCUlCqmiNHOAYK6VFyq2HFsOOmJIY' http://localhost:8080/some_url


### PR DESCRIPTION
The JWT specification allows "aud" to be an array of strings: https://tools.ietf.org/html/rfc7519#section-4.1.3

This relaxes type checking in the request matcher so that arrays can be matched against in the payload.