### PR TITLE
Add support for the latest version of Wiremock (2.26.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ There are three ways of running the extension:
 1. Standalone, e.g.
 
     ```sh
-    java -jar build/libs/wiremock-jwt-extension-0.5-standalone.jar
+    java -jar build/libs/wiremock-jwt-extension-0.6-standalone.jar
     ```
     
 2. As an extension of the WireMock standalone JAR, e.g.
 
     ```sh
-    wget -nc http://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/2.14.0/wiremock-standalone-2.14.0.jar
+    wget -nc http://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/2.26.3/wiremock-standalone-2.26.3.jar
     java \
-            -cp wiremock-standalone-2.14.0.jar:build/libs/wiremock-jwt-extension-0.5.jar \
+            -cp wiremock-standalone-2.26.3.jar:build/libs/wiremock-jwt-extension-0.6.jar \
             com.github.tomakehurst.wiremock.standalone.WireMockServerRunner \
             --extensions="com.github.masonm.JwtMatcherExtension,com.github.masonm.JwtStubMappingTransformer"
     ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ There are three ways of running the extension:
 2. As an extension of the WireMock standalone JAR, e.g.
 
     ```sh
-    wget -nc http://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/2.26.3/wiremock-standalone-2.26.3.jar
+    wget -nc https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/2.26.3/wiremock-standalone-2.26.3.jar
     java \
             -cp wiremock-standalone-2.26.3.jar:build/libs/wiremock-jwt-extension-0.6.jar \
             com.github.tomakehurst.wiremock.standalone.WireMockServerRunner \

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 sourceCompatibility = 1.7
 group = 'com.github.masonm'
 archivesBaseName = 'wiremock-jwt-extension'
-version = '0.5'
+version = '0.6'
 
 repositories {
     // Canonical URLs at https://central.sonatype.org/pages/consumers.html
@@ -31,7 +31,7 @@ task standaloneJar (type: Jar) {
     }
 
     from {
-        configurations.compile.plus(configurations.shadow).collect {
+        (configurations.compile + configurations.shadow).collect {
             it.isDirectory() ? it : zipTree(it)
         }
     }
@@ -112,7 +112,7 @@ dependencies {
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.8.9'
     compile group: 'commons-codec', name: 'commons-codec', version: '1.11'
 
-    shadow group: 'com.github.tomakehurst', name: 'wiremock', version: '2.14.0'
+    shadow group: 'com.github.tomakehurst', name: 'wiremock', version: '2.26.3'
 
     testCompile group: 'com.google.guava', name: 'guava', version: '18.0'
     testCompile group: 'junit', name: 'junit', version: '4.12'
@@ -121,6 +121,6 @@ dependencies {
     testCompile group: 'org.jmock', name: 'jmock-junit4', version: '2.5.1'
     testCompile group: 'org.skyscreamer', name: 'jsonassert', version: '1.2.3'
     testCompile group: 'com.toomuchcoding.jsonassert', name: 'jsonassert', version: '0.4.7'
-    testCompile group: 'com.github.tomakehurst', name: 'wiremock', version: '2.14.0'
-    testCompile group: 'com.github.tomakehurst', name: 'wiremock', version: '2.14.0', classifier: 'tests'
+    testCompile group: 'com.github.tomakehurst', name: 'wiremock', version: '2.26.3'
+    testCompile group: 'com.github.tomakehurst', name: 'wiremock', version: '2.26.3', classifier: 'tests'
 }

--- a/src/main/java/com/github/masonm/JwtStubMappingTransformer.java
+++ b/src/main/java/com/github/masonm/JwtStubMappingTransformer.java
@@ -14,6 +14,8 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import static com.google.common.net.HttpHeaders.AUTHORIZATION;
+
 public class JwtStubMappingTransformer extends StubMappingTransformer {
     public static final String PAYLOAD_FIELDS = "payloadFields";
 
@@ -39,11 +41,11 @@ public class JwtStubMappingTransformer extends StubMappingTransformer {
         }
 
         Map<String, MultiValuePattern> requestHeaders = stubMapping.getRequest().getHeaders();
-        if (requestHeaders == null || !requestHeaders.containsKey("Authorization")) {
+        if (requestHeaders == null || !requestHeaders.containsKey(AUTHORIZATION)) {
             return stubMapping;
         }
 
-        String authHeader = requestHeaders.get("Authorization").getExpected();
+        String authHeader = requestHeaders.get(AUTHORIZATION).getExpected();
         Parameters requestMatcherParameters = getRequestMatcherParameter(
             Jwt.fromAuthHeader(authHeader),
             parameters.get(PAYLOAD_FIELDS)
@@ -64,7 +66,7 @@ public class JwtStubMappingTransformer extends StubMappingTransformer {
         Map<String, MultiValuePattern> newHeaders = null;
         if (outer.getHeaders() != null) {
             newHeaders = new LinkedHashMap<>(outer.getHeaders());
-            newHeaders.remove("Authorization");
+            newHeaders.remove(AUTHORIZATION);
             if (newHeaders.isEmpty()) {
                 newHeaders = null;
             }

--- a/src/main/java/com/github/masonm/JwtStubMappingTransformer.java
+++ b/src/main/java/com/github/masonm/JwtStubMappingTransformer.java
@@ -79,6 +79,7 @@ public class JwtStubMappingTransformer extends StubMappingTransformer {
             outer.getBasicAuthCredentials(),
             outer.getBodyPatterns(),
             null,
+            null,
             outer.getMultipartPatterns()
         );
     }

--- a/test-helpers.sh
+++ b/test-helpers.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-VERSION=0.5
+VERSION=0.6
 
 launchWiremock() {
 	echo "Launching Wiremock and setting up proxying"
-	java -cp wiremock-standalone-2.14.0.jar:build/libs/wiremock-jwt-extension-${VERSION}.jar com.github.tomakehurst.wiremock.standalone.WireMockServerRunner --extensions="com.github.masonm.JwtMatcherExtension,com.github.masonm.JwtStubMappingTransformer" &
+	java -cp wiremock-standalone-2.26.3.jar:build/libs/wiremock-jwt-extension-${VERSION}.jar com.github.tomakehurst.wiremock.standalone.WireMockServerRunner --extensions="com.github.masonm.JwtMatcherExtension,com.github.masonm.JwtStubMappingTransformer" &
 	#java -jar build/libs/wiremock-jwt-extension-${VERSION}-standalone.jar &
 	WIREMOCK_PID=$!
 	trap "kill $WIREMOCK_PID" exit


### PR DESCRIPTION
The version of Wiremock currently supported is 2.14.0 which is over two years old.

A lot of new features have been introduced in Wiremock since then. I wanted to use the support for multiple mappings in a single file.

I have bumped the version to 0.6 and have also replaced a string literal with a constant from the Guava library which was already a dependency.