### PR TITLE
update jackson version to 2.12.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,8 +108,8 @@ uploadArchives {
 }
 
 dependencies {
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.8.9'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.8.9'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.12.3'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.3'
     compile group: 'commons-codec', name: 'commons-codec', version: '1.11'
 
     shadow group: 'com.github.tomakehurst', name: 'wiremock', version: '2.27.2'


### PR DESCRIPTION
Jackson version `2.8.9` has known vulnerabilities. In order to mitigate them update for the new version `2.12.3` is required. 