### PR TITLE
Update build.gradle to bump jackson libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,8 +109,8 @@ uploadArchives {
 }
 
 dependencies {
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.13.2'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.2.2'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.14.2'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.14.2'
     compile group: 'commons-codec', name: 'commons-codec', version: '1.15'
 
     shadow group: 'com.github.tomakehurst', name: 'wiremock-jre8', version: '2.33.2'


### PR DESCRIPTION
As there are vulnerabilities with 2.13.2 version.
https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind/2.13.2.2

Bumping the versions to latest jackson versions
https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind/2.14.2

And
https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core/2.14.2